### PR TITLE
osd/OSD: allow new message type "MSG_OSD_MARK_ME_DOWN_AND_DEAD" send by OSD

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4546,6 +4546,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
     case MSG_OSD_BEACON:
     case MSG_OSD_MARK_ME_DOWN:
     case MSG_OSD_MARK_ME_DEAD:
+    case MSG_OSD_MARK_ME_DOWN_AND_DEAD:
     case MSG_OSD_FULL:
     case MSG_OSD_FAILURE:
     case MSG_OSD_BOOT:


### PR DESCRIPTION
Since the new message type is send from a OSD, we should allow it send by one

Signed-off-by: Manuel Lausch <mail@manuellausch.de>